### PR TITLE
Reduce size of gem considerably by only including files from spec direct...

### DIFF
--- a/entangled.gemspec
+++ b/entangled.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files -z`.split("\x0")
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  s.test_files = Dir["spec/**/*"]
+  s.test_files    = `git ls-files -z spec`.split("\x0")
   s.require_paths = ["lib"]
 
   s.add_development_dependency 'bundler', '~> 1.7'

--- a/lib/entangled/version.rb
+++ b/lib/entangled/version.rb
@@ -1,3 +1,3 @@
 module Entangled
-  VERSION = "0.0.16"
+  VERSION = "0.0.17"
 end


### PR DESCRIPTION
...ory that are not ignored with git, thereby excluding npm and bower packages