### PR TITLE
Allow as_json options to be overridden in model

### DIFF
--- a/lib/entangled/model.rb
+++ b/lib/entangled/model.rb
@@ -69,8 +69,8 @@ module Entangled
       # its errors. This is necessary so that errors
       # are sent back to the client along with the
       # resource on create and update
-      def as_json(options = {})
-        attributes.merge(errors: errors).as_json
+      def as_json(options = nil)
+        super(options || attributes).merge(errors: errors).as_json
       end
 
       # Build channels. Channels always at least include


### PR DESCRIPTION
Entangled::Model overrides as_json, but doesnt pass it's parameters up the chain to super, so we lose the ability to effectivey override it again down in the model. 

This patch is an attempt at addressing that.