### PR TITLE
Improve channel creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,6 @@ The gem relies heavily on convention over configuration and currently only works
 ## Development Priorities
 The following features are to be implemented next:
 
-- Do not build channels for nil parents
 - Make prefix of create path `create_message` instead of `create_messages`
 - Support `belongsTo` in front end
 - Support `has_one` association in back end and front end

--- a/lib/entangled/model.rb
+++ b/lib/entangled/model.rb
@@ -82,6 +82,11 @@ module Entangled
       # recursively
       def channels(tail = '')
         channels = []
+
+        # If the record is not persisted, it should not have
+        # any channels
+        return channels unless persisted?
+
         plural_name = self.class.name.underscore.pluralize
 
         # Add collection channel for child only. If the tails
@@ -131,11 +136,13 @@ module Entangled
         }.to_json
       end
 
-      # Find parent classes from belongs_to associations
+      # Find parent classes from belongs_to associations that
+      # are not nil
       def parents
         self.class.
           reflect_on_all_associations(:belongs_to).
-          map{ |a| send(a.name) }
+          map{ |a| send(a.name) }.
+          reject(&:nil?)
       end
     end
     

--- a/lib/entangled/version.rb
+++ b/lib/entangled/version.rb
@@ -1,3 +1,3 @@
 module Entangled
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end

--- a/spec/models/channels_spec.rb
+++ b/spec/models/channels_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe 'Channels', type: :model do
 
   let!(:child) { Child.create(parent_id: parent.id) }
 
+  # Child without parents
+  let!(:orphan) do
+    child = Child.new
+    child.save(validate: false)
+    child
+  end
+
+  # Child that's not persisted
+  let!(:fetus) { Child.new }
+
   describe "grandmother's channels" do
     it 'has two channels' do
       expect(grandmother.channels.size).to eq 2
@@ -24,7 +34,8 @@ RSpec.describe 'Channels', type: :model do
     end
 
     it 'has a member channel' do
-      expect(grandmother.channels).to include "/grandmothers/#{grandmother.to_param}"
+      channel = "/grandmothers/#{grandmother.to_param}"
+      expect(grandmother.channels).to include channel
     end
   end
 
@@ -38,7 +49,8 @@ RSpec.describe 'Channels', type: :model do
     end
 
     it 'has a member channel' do
-      expect(grandfather.channels).to include "/grandfathers/#{grandfather.to_param}"
+      channel = "/grandfathers/#{grandfather.to_param}"
+      expect(grandfather.channels).to include channel
     end
   end
 
@@ -56,19 +68,25 @@ RSpec.describe 'Channels', type: :model do
     end
 
     it 'has a collection channel nested under its grandmother' do
-      expect(parent.channels).to include "/grandmothers/#{grandmother.to_param}/parents"
+      channel = "/grandmothers/#{grandmother.to_param}/parents"
+      expect(parent.channels).to include channel
     end
 
     it 'has a member channel nested under its grandmother' do
-      expect(parent.channels).to include "/grandmothers/#{grandmother.to_param}/parents/#{parent.to_param}"
+      channel = "/grandmothers/#{grandmother.to_param}"\
+                "/parents/#{parent.to_param}"
+      expect(parent.channels).to include channel
     end
 
     it 'has a collection channel nested under its grandfather' do
-      expect(parent.channels).to include "/grandfathers/#{grandfather.to_param}/parents"
+      channel = "/grandfathers/#{grandfather.to_param}/parents"
+      expect(parent.channels).to include channel
     end
 
     it 'has a member channel nested under its grandfather' do
-      expect(parent.channels).to include "/grandfathers/#{grandfather.to_param}/parents/#{parent.to_param}"
+      channel = "/grandfathers/#{grandfather.to_param}"\
+                "/parents/#{parent.to_param}"
+      expect(parent.channels).to include channel
     end
   end
 
@@ -90,23 +108,44 @@ RSpec.describe 'Channels', type: :model do
     end
 
     it 'has a member channel nested under its parent' do
-      expect(child.channels).to include "/parents/#{parent.to_param}/children/#{child.to_param}"
+      channel = "/parents/#{parent.to_param}/children/#{child.to_param}"
+      expect(child.channels).to include channel
     end
 
     it 'has a collection channel nested under its parent and grandmother' do
-      expect(child.channels).to include "/grandmothers/#{grandmother.to_param}/parents/#{parent.to_param}/children"
+      channel = "/grandmothers/#{grandmother.to_param}"\
+                "/parents/#{parent.to_param}/children"
+      expect(child.channels).to include channel
     end
 
     it 'has a member channel nested under its parent and grandmother' do
-      expect(child.channels).to include "/grandmothers/#{grandmother.to_param}/parents/#{parent.to_param}/children/#{child.to_param}"
+      channel = "/grandmothers/#{grandmother.to_param}"\
+                "/parents/#{parent.to_param}/children/#{child.to_param}"
+      expect(child.channels).to include channel
     end
 
     it 'has a collection channel nested under its parent and grandfather' do
-      expect(child.channels).to include "/grandfathers/#{grandfather.to_param}/parents/#{parent.to_param}/children"
+      channel = "/grandfathers/#{grandfather.to_param}"\
+                "/parents/#{parent.to_param}/children"
+      expect(child.channels).to include channel
     end
 
     it 'has a member channel nested under its parent and grandfather' do
-      expect(child.channels).to include "/grandfathers/#{grandfather.to_param}/parents/#{parent.to_param}/children/#{child.to_param}"
+      channel = "/grandfathers/#{grandfather.to_param}"\
+                "/parents/#{parent.to_param}/children/#{child.to_param}"
+      expect(child.channels).to include channel
+    end
+  end
+
+  describe "orphan's channels" do
+    it 'does not have any parent channels since it has no parent' do
+      expect(orphan.channels.size).to eq 2
+    end
+  end
+
+  describe "fetus's channel" do
+    it 'does not have any channels since it is not persisted' do
+      expect(fetus.channels).to be_empty
     end
   end
 end


### PR DESCRIPTION
These commits make sure that channels are not built for a non-persisted record. Also, nil parents are not included in a child's channels. Lastly, the channels spec's legibility is improved and the version number bumped up.